### PR TITLE
Fix AKS Cluster Deployment Failure by Setting Supported Kubernetes Version

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -65,6 +65,7 @@ module aks 'br/public:avm/ptn/azd/aks:0.2.0' = {
     systemPoolSize: systemPoolType
     disableLocalAccounts: false
     aadProfile: null
+    kubernetesVersion: '1.33.5'
   }
 }
 


### PR DESCRIPTION
Fixes issue https://github.com/Azure-Samples/todo-nodejs-mongo-aks/issues/18. This PR resolves it by adding `kubernetesVersion: '1.33.5'` to the module `aks` in the [infra/main.bicep](https://github.com/Azure-Samples/todo-nodejs-mongo-aks/blob/main/infra/main.bicep#L53) file.

@rajeshkamal5050, @vhvb1989 and @JeffreyCA for notification.